### PR TITLE
Sharing individual blog posts with dynamic og:image

### DIFF
--- a/angular-app/src/app/components/header/header.component.html
+++ b/angular-app/src/app/components/header/header.component.html
@@ -30,6 +30,13 @@
             </span></button>
         </div>
         }
+        @if (!showMainHeader) {
+          <div class="share">
+            <button (click)="modalService.showShareDialog=true"><span class="material-symbols-outlined">
+                share
+              </span></button>
+          </div>
+          }
         <div class="theme-control">
           @if (themeService.themeSignal() == 'dark') {
           <button (click)="toggleTheme()"><span class="material-symbols-outlined">
@@ -78,6 +85,9 @@
 
 @if (modalService.showSettingsDialog) {
 <app-settings-dialog></app-settings-dialog>
+}
+@if (modalService.showShareDialog) {
+<app-share-dialog></app-share-dialog>
 }
 @if (modalService.showFollowDialog) {
 <app-follow-dialog></app-follow-dialog>

--- a/angular-app/src/app/components/header/header.component.ts
+++ b/angular-app/src/app/components/header/header.component.ts
@@ -4,7 +4,12 @@ import { Subscription } from "rxjs";
 import { BlogService } from "../../services/blog.service";
 import { AsyncPipe, KeyValuePipe } from "@angular/common";
 import { BlogInfo, BlogLinks } from "../../models/blog-info";
-import { ActivatedRoute, NavigationEnd, Router, RouterLink } from "@angular/router";
+import {
+	ActivatedRoute,
+	NavigationEnd,
+	Router,
+	RouterLink,
+} from "@angular/router";
 import { SeriesList } from "../../models/post";
 import { FollowDialogComponent } from "../../partials/follow-dialog/follow-dialog.component";
 import { SidenavComponent } from "../sidenav/sidenav.component";
@@ -12,18 +17,28 @@ import { ModalService } from "../../services/modal.service";
 import { IconService } from "../../services/icon.service";
 import { SvgIconComponent } from "../../partials/svg-icon/svg-icon.component";
 import { SettingsDialogComponent } from "../../partials/settings-dialog/settings-dialog.component";
+import { ShareDialogComponent } from "../../partials/share-dialog/share-dialog.component";
 
 @Component({
 	selector: "app-header",
 	standalone: true,
-	imports: [KeyValuePipe, AsyncPipe, RouterLink, SidenavComponent, FollowDialogComponent, SvgIconComponent, SettingsDialogComponent],
+	imports: [
+		KeyValuePipe,
+		AsyncPipe,
+		RouterLink,
+		SidenavComponent,
+		FollowDialogComponent,
+		SvgIconComponent,
+		SettingsDialogComponent,
+		ShareDialogComponent,
+	],
 	templateUrl: "./header.component.html",
 	styleUrl: "./header.component.scss",
 })
 export class HeaderComponent implements OnInit, OnDestroy {
-  showMainHeader: boolean = true;
-  sidenavOpen: boolean = false;
-  blogURL!: string;
+	showMainHeader: boolean = true;
+	sidenavOpen: boolean = false;
+	blogURL!: string;
 	blogInfo!: BlogInfo;
 	blogName: string = "";
 	// start with default image to prevent 404 when returning from post-details page
@@ -33,13 +48,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
 	themeService: ThemeService = inject(ThemeService);
 	blogService: BlogService = inject(BlogService);
 	modalService: ModalService = inject(ModalService);
-  iconService: IconService = inject(IconService);
-  private route = inject(ActivatedRoute);
-  private router = inject(Router);
+	iconService: IconService = inject(IconService);
+	private route = inject(ActivatedRoute);
+	private router = inject(Router);
 	private querySubscription?: Subscription;
 
 	ngOnInit(): void {
-    this.blogURL = this.blogService.getBlogURL();
+		this.blogURL = this.blogService.getBlogURL();
 		this.querySubscription = this.blogService
 			.getBlogInfo(this.blogURL)
 			.subscribe((data) => {
@@ -64,24 +79,25 @@ export class HeaderComponent implements OnInit, OnDestroy {
 			.subscribe((data) => {
 				this.seriesList = data;
 			});
-    this.router.events.subscribe((event) => {
-      if (event instanceof NavigationEnd) {
-        this.showMainHeader = !this.route.snapshot.firstChild?.paramMap.has('postSlug');
-      }
-    });
+		this.router.events.subscribe((event) => {
+			if (event instanceof NavigationEnd) {
+				this.showMainHeader =
+					!this.route.snapshot.firstChild?.paramMap.has("postSlug");
+			}
+		});
 	}
 
 	toggleTheme(): void {
 		this.themeService.updateTheme();
 	}
 
-  toggleSidenav() {
+	toggleSidenav() {
 		this.sidenavOpen = !this.sidenavOpen;
 	}
 
-  getIcon(key: string) {
-    return this.iconService.getIcon(key);
-  }
+	getIcon(key: string) {
+		return this.iconService.getIcon(key);
+	}
 
 	ngOnDestroy(): void {
 		this.querySubscription?.unsubscribe();

--- a/angular-app/src/app/components/post-details/post-details.component.ts
+++ b/angular-app/src/app/components/post-details/post-details.component.ts
@@ -54,7 +54,15 @@ export class PostDetailsComponent implements OnInit, OnDestroy {
 		this.themeService.updateTheme();
 	}
 
+  private updateOgImageMetaTag(imageUrl: string): void {
+    const metaTag = document.querySelector('meta[property="og:image"]');
+    if (metaTag) {
+      metaTag.setAttribute('content', imageUrl);
+    }
+  }
+
 	ngOnDestroy(): void {
 		this.querySubscription?.unsubscribe();
+    this.blogService.resetOgImageMetaTagToDefault();
 	}
 }

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.html
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.html
@@ -12,8 +12,8 @@
   </div>
   <div class="dialog-actions">
     <button class="copy-btn" (click)="copyPostURL()">Copy Post Link</button>
-    <button class="linkedin-btn" (click)="shareOnLinkedIn()">Share on LinkedIn</button>
-    <button class="twitter-btn" (click)="shareOnTwitter()">Share on Twitter</button>
+    <button class="linkedin-btn" (click)="shareOnLinkedIn()"><app-svg-icon [icon]="linkedinIcon"></app-svg-icon>Share on LinkedIn</button>
+    <button class="twitter-btn" (click)="shareOnTwitter()"><app-svg-icon [icon]="twitterIcon"></app-svg-icon>Share on Twitter</button>
   </div>
 </div>
 

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.html
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.html
@@ -12,6 +12,8 @@
   </div>
   <div class="dialog-actions">
     <button class="copy-btn" (click)="copyPostURL()">Copy Post Link</button>
+    <button class="linkedin-btn" (click)="shareOnLinkedIn()">Share on LinkedIn</button>
+    <button class="twitter-btn" (click)="shareOnTwitter()">Share on Twitter</button>
   </div>
 </div>
 

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.html
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.html
@@ -1,0 +1,18 @@
+<div class="overlay" (click)="modalService.showShareDialog=false"></div>
+<div class="dialog-container">
+  <div class="close">
+    <span class="material-symbols-outlined close-btn" (click)="modalService.showShareDialog=false">
+      close
+      </span>
+  </div>
+  <div class="dialog-header">
+    <h3>Share this Blog Post:</h3>
+  </div>
+  <div class="dialog-content">
+  </div>
+  <div class="dialog-actions">
+    <button class="copy-btn" (click)="copyPostURL()">Copy Post Link</button>
+  </div>
+</div>
+
+

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.scss
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.scss
@@ -39,20 +39,13 @@
   .dialog-header {
     padding: 0 2rem;
 
-    img {
-      width: 5rem;
-      height: 5rem;
-      margin: 1rem;
-      border-radius: 50%;
+    h3 {
+      margin: 0.5rem 0;
     }
   }
 
   .dialog-content {
     padding: 0 2rem;
-
-    h3 {
-      margin: 0.5rem 0;
-    }
   }
 
   .dialog-actions {
@@ -62,35 +55,11 @@
     justify-content: center;
     padding: 0 2rem;
 
-    p {
-      font-size: 0.8rem;
-      text-align: center;
-    }
-
-    .button {
+    button {
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #2563eb;
-      color: #fff;
-      font-size: 1.1rem;
-      width: 100%;
-      padding: 0.7rem;
-      margin: 1rem 0;
-      border: none;
-      border-radius: 3rem;
-
-      img {
-        width: 1.5rem;
-        height: 1.5rem;
-        margin-right: 0.5rem;
-      }
-    }
-
-    .link {
-      color: #2563eb;
-      font-size: 0.8.5rem;
-      margin: 0;
+      font-size: 1rem;
     }
   }
 }

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.scss
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.scss
@@ -60,11 +60,12 @@
 
     button {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
       font-size: 1rem;
       width: 16rem;
       padding: 0.7rem;
+      gap: 0.5rem;
     }
   }
 }

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.scss
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.scss
@@ -18,8 +18,8 @@
   left: 0;
   right: 0;
   bottom: 0;
-  width: 26vw;
-  height: 50vh;
+  width: 20vw;
+  height: 42vh;
   margin: auto;
   padding: 0 0.8rem;
   border-radius: 0.3rem;
@@ -38,6 +38,7 @@
 
   .dialog-header {
     padding: 0 2rem;
+    margin-bottom: 1rem;
 
     h3 {
       margin: 0.5rem 0;
@@ -54,12 +55,16 @@
     align-items: center;
     justify-content: center;
     padding: 0 2rem;
+    margin-bottom: 1rem;
+    gap: 1rem;
 
     button {
       display: flex;
       align-items: center;
       justify-content: center;
       font-size: 1rem;
+      width: 16rem;
+      padding: 0.7rem;
     }
   }
 }

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.spec.ts
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShareDialogComponent } from './share-dialog.component';
+
+describe('ShareDialogComponent', () => {
+  let component: ShareDialogComponent;
+  let fixture: ComponentFixture<ShareDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ShareDialogComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ShareDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.ts
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.ts
@@ -31,4 +31,14 @@ export class ShareDialogComponent implements OnInit {
 			error: (err: any) => console.error('Failed to copy: ', err),
 		});
 	}
+
+  shareOnLinkedIn(): void {
+    const linkedinShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(this.currentUrl)}`;
+    window.open(linkedinShareUrl, '_blank');
+  }
+
+  shareOnTwitter(): void {
+    const twitterShareUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(this.currentUrl)}`;
+    window.open(twitterShareUrl, '_blank');
+  }
 }

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.ts
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit, inject } from "@angular/core";
+import { BlogService } from "../../services/blog.service";
+import { ModalService } from "../../services/modal.service";
+import { from, timer } from "rxjs";
+
+@Component({
+	selector: "app-share-dialog",
+	standalone: true,
+	imports: [],
+	templateUrl: "./share-dialog.component.html",
+	styleUrl: "./share-dialog.component.scss",
+})
+export class ShareDialogComponent implements OnInit {
+	currentUrl: string = "";
+	modalService: ModalService = inject(ModalService);
+	blogService: BlogService = inject(BlogService);
+
+	ngOnInit(): void {
+    this.currentUrl = window.location.href;
+	}
+
+  copyPostURL(): void {
+		from (
+			navigator.clipboard.writeText(this.currentUrl)
+		).subscribe({
+			next: () => {
+        const buttonElement = document.querySelector(".copy-btn") as HTMLButtonElement;
+				buttonElement.textContent = "Post Link Copied ✅";
+				timer(1500).subscribe(() => (buttonElement.textContent = "Copy Post Link"));
+			},
+			error: (err: any) => console.error('Failed to copy: ', err),
+		});
+	}
+}

--- a/angular-app/src/app/partials/share-dialog/share-dialog.component.ts
+++ b/angular-app/src/app/partials/share-dialog/share-dialog.component.ts
@@ -2,16 +2,19 @@ import { Component, OnInit, inject } from "@angular/core";
 import { BlogService } from "../../services/blog.service";
 import { ModalService } from "../../services/modal.service";
 import { from, timer } from "rxjs";
+import { SvgIconComponent } from "../svg-icon/svg-icon.component";
 
 @Component({
 	selector: "app-share-dialog",
 	standalone: true,
-	imports: [],
+	imports: [SvgIconComponent],
 	templateUrl: "./share-dialog.component.html",
 	styleUrl: "./share-dialog.component.scss",
 })
 export class ShareDialogComponent implements OnInit {
 	currentUrl: string = "";
+  linkedinIcon: string = "linkedin";
+  twitterIcon: string = "twitter";
 	modalService: ModalService = inject(ModalService);
 	blogService: BlogService = inject(BlogService);
 
@@ -25,7 +28,7 @@ export class ShareDialogComponent implements OnInit {
 		).subscribe({
 			next: () => {
         const buttonElement = document.querySelector(".copy-btn") as HTMLButtonElement;
-				buttonElement.textContent = "Post Link Copied ✅";
+				buttonElement.textContent = "✅ Post Link Copied";
 				timer(1500).subscribe(() => (buttonElement.textContent = "Copy Post Link"));
 			},
 			error: (err: any) => console.error('Failed to copy: ', err),

--- a/angular-app/src/app/services/blog.service.ts
+++ b/angular-app/src/app/services/blog.service.ts
@@ -110,6 +110,28 @@ export class BlogService {
         slug: slug
       },
     })
-    .valueChanges.pipe(map(({ data }) => data.publication.post));
+    .valueChanges.pipe(
+      map(({ data }) => {
+        const post = data.publication.post;
+        this.updateOgImageMetaTag(post.coverImage.url); // Update og:image meta tag
+        return post;
+      })
+    );
+  }
+
+  private updateOgImageMetaTag(imageUrl: string): void {
+    const metaTag = document.querySelector('meta[property="og:image"]');
+    const metaTagSecure = document.querySelector('meta[property="og:image:secure_url"]');
+    if (metaTag) {
+      metaTag.setAttribute('content', imageUrl);
+    }
+    if (metaTagSecure) {
+      metaTagSecure.setAttribute('content', imageUrl);
+    }
+  }
+
+  resetOgImageMetaTagToDefault(): void {
+    const defaultImageUrl = "/assets/images/angular-anguhashblog-dark.jpg";
+    this.updateOgImageMetaTag(defaultImageUrl);
   }
 }

--- a/angular-app/src/app/services/modal.service.ts
+++ b/angular-app/src/app/services/modal.service.ts
@@ -5,5 +5,6 @@ import { Injectable } from '@angular/core';
 })
 export class ModalService {
   showSettingsDialog = false;
+  showShareDialog = false;
   showFollowDialog = false;
 }

--- a/angular-app/src/styles.scss
+++ b/angular-app/src/styles.scss
@@ -121,9 +121,9 @@ article {
   }
 
   .dialog-container {
-    background-color: #000;
+    background-color: #444;
     color: #c2c2c2;
-    box-shadow: 5px 5px 4px #202020d9;
+    box-shadow: 5px 5px 4px #000000d9;
   }
 
   .content {


### PR DESCRIPTION
## This PR Closes Issue 
closes #15 

## Description
- set up a function in `blog-service` to dynamically change the `og:image` and `og:image:secure_url` href values to `coverImage` of the blog post 
## reverting to default image in the `OnDestroy` lifecycle in post-details
- for the native version I have added another button to load only in `page-details`
- it is a share button implemented like the rest of the buttons in header with a `share` icon
- created a new `share-dialog` component in partials which is triggered by the `share` button in header
the `share-dialog` allows users to 
- copy the post url
- share on linked in - must be checked on deployed 
- share on twitter
- adjusted styling where needed

## What type of PR is this? (check all applicable)

- [x] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
